### PR TITLE
Extension Decompression Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@
 
 A drag'n'drop image converter for Wreckfest.
 
-v1.6.0 released 2021-05-21  
-Download binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.6.0.zip) (35.1KB)
+v1.6.1 released 2025-02-03
+Download v1.6.1 binary [here](https://github.com/RavenStryker/Breckfest/releases/tag/Release)
+Download v1.6.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.6.0.zip) (35.1KB)
+Download v1.5.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.5.0.zip)
+Download v1.4.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.4.0.zip)
+Download v1.3.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.3.0.zip)
 
 How to use:  
 Drop a bmap on Breckfest.exe to get a png file.  

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A drag'n'drop image converter for Wreckfest.
 
 v1.6.2 released 2025-02-25  
-Download v1.6.2 binary [here](https://github.com/RavenStryker/Breckfest/releases/tag/1.6.2).
+Download v1.6.2 binary [here](https://github.com/RavenStryker/Breckfest/releases/tag/1.6.2)  
 Download v1.6.1 binary [here](https://github.com/RavenStryker/Breckfest/releases/tag/1.6.1)  
 Download v1.6.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.6.0.zip)  
 Download v1.5.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.5.0.zip)  

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Commandline options:
 -f[orce] : Breckfest will automatically overwrite files  
 -dump : Decompresses any valid Wreckfest compressed file  
 -compress : Compresses any valid Wreckfest decompressed file  
--norename : Prevent Breckfest from adding the ".x" (danger!  this combined with -force is a dangerous combination)
--png : Completely unnecessary command to tell Breckfest to convert bmap to png
--dds : Don't output png files, write dds files instead
--tga : Say no to png and dds, TGA is the new king
+-norename : Prevent Breckfest from adding the ".x" (danger!  this combined with -force is a dangerous combination)  
+-png : Completely unnecessary command to tell Breckfest to convert bmap to png  
+-dds : Don't output png files, write dds files instead  
+-tga : Say no to png and dds, TGA is the new king  
 _Breckfest.exe -c "c:\path\to\file.png"_ will create clutter bmap file.x.bmap  
-_Breckfest.exe -clutter "c:\path\to\file.png"_ will do the same thing
+_Breckfest.exe -clutter "c:\path\to\file.png"_ will do the same thing  
 
 Filename options:  
 Filename.clutter.png will be processed as -clutter and saved as Filename.x.bmap  

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 A drag'n'drop image converter for Wreckfest.
 
-v1.6.1 released 2025-02-03  
-Download v1.6.1 binary [here](https://github.com/RavenStryker/Breckfest/releases/tag/Release)  
+v1.6.2 released 2025-02-25  
+Download v1.6.2 binary [here](https://github.com/RavenStryker/Breckfest/releases/tag/1.6.2).
+Download v1.6.1 binary [here](https://github.com/RavenStryker/Breckfest/releases/tag/1.6.1)  
 Download v1.6.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.6.0.zip)  
 Download v1.5.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.5.0.zip)  
 Download v1.4.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.4.0.zip)  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Breckfest v1.6.0**
+**Breckfest v1.6.1**
 
 ![alt text](http://www.toxic-ragers.co.uk/images/misc/breckfest.png "Breckfest")
 
@@ -41,9 +41,12 @@ Filename.dxt1.png will be processed as -dxt1 and saved as Filename.x.bmap
 Filename.dxt5.png will be processed as -dxt5 and saved as Filename.x.bmap  
 And so on
 
-**Changelog**
+**Changelog**  
+**v1.6.1**  
+Updated DDS.cs so that it can properly handle decompressing _n files from Wreckfest to .tga, .png or .dds and the color output is accurate.  
+Made changed so that .tga, .png and .dds can all be decompressed through the command line. Also made them compatible with the -norename/-nr flag so when decompressing you can have the files keep the compressed naming format.  
 
-**v1.6.0**
+**v1.6.0**  
 Added -norename based on work by [talberti](https://github.com/talberti)  
 Added -dds  
 Updated LibSquishNet to the super speedy v2.0.0  

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Filename.dxt5.png will be processed as -dxt5 and saved as Filename.x.bmap
 And so on
 
 **Changelog**  
+**v1.6.2**  
+Fix backward compatibility for older BC5U files (2018 Normal Maps)  
+- Detect BC5U (FourCC value 1429553986) in DDS loading and map it to ATI2.  
+- Update conditional block in DDS.Load to explicitly cast PixelFormatFourCC to uint.  
+- This change enables proper decompression of legacy 2018 files using ATI2 logic.  
+
 **v1.6.1**  
 Updated DDS.cs so that it can properly handle decompressing _n files from Wreckfest to .tga, .png or .dds and the color output is accurate.  
 Made changed so that .tga, .png and .dds can all be decompressed through the command line. Also made them compatible with the -norename/-nr flag so when decompressing you can have the files keep the compressed naming format.  

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 A drag'n'drop image converter for Wreckfest.
 
-v1.6.1 released 2025-02-03
-Download v1.6.1 binary [here](https://github.com/RavenStryker/Breckfest/releases/tag/Release)
-Download v1.6.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.6.0.zip) (35.1KB)
-Download v1.5.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.5.0.zip)
-Download v1.4.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.4.0.zip)
-Download v1.3.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.3.0.zip)
+v1.6.1 released 2025-02-03  
+Download v1.6.1 binary [here](https://github.com/RavenStryker/Breckfest/releases/tag/Release)  
+Download v1.6.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.6.0.zip)  
+Download v1.5.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.5.0.zip)  
+Download v1.4.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.4.0.zip)  
+Download v1.3.0 binary [here](https://www.toxic-ragers.co.uk/files/tools/breckfest/Breckfest.v1.3.0.zip)  
 
 How to use:  
 Drop a bmap on Breckfest.exe to get a png file.  

--- a/breckFest/BMAP.cs
+++ b/breckFest/BMAP.cs
@@ -141,7 +141,7 @@ namespace breckFest
                         TGA.FromBitmap(DDS.Decompress()).Save(path);
                         break;
                 }
-                
+
             }
             else
             {

--- a/breckFest/DDS.cs
+++ b/breckFest/DDS.cs
@@ -198,7 +198,16 @@ namespace breckFest
 
                 if (dds.PixelFormat.Flags.HasFlag(PixelFormatFlags.DDPF_FOURCC))
                 {
-                    dds.Format = (D3DFormat)dds.PixelFormat.FourCC;
+                    uint fourCC = (uint)dds.PixelFormat.FourCC;
+                    // Map older BC5U files (1429553986) to ATI2 for backward compatibility.
+                    if (fourCC == 1429553986) // "BC5U"
+                    {
+                        dds.Format = D3DFormat.ATI2;
+                    }
+                    else
+                    {
+                        dds.Format = (D3DFormat)fourCC;
+                    }
                 }
                 else if (dds.PixelFormat.Flags.HasFlag(PixelFormatFlags.DDPF_RGB) &&
                          dds.PixelFormat.Flags.HasFlag(PixelFormatFlags.DDPF_ALPHAPIXELS))

--- a/breckFest/Properties/AssemblyInfo.cs
+++ b/breckFest/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.1.0")]
-[assembly: AssemblyFileVersion("1.6.1.0")]
+[assembly: AssemblyVersion("1.6.2.0")]
+[assembly: AssemblyFileVersion("1.6.2.0")]

--- a/breckFest/Properties/AssemblyInfo.cs
+++ b/breckFest/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Breckfest")]
@@ -14,8 +14,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -25,12 +25,12 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.6.0.0")]
+[assembly: AssemblyVersion("1.6.1.0")]
+[assembly: AssemblyFileVersion("1.6.1.0")]

--- a/breckFest/app.config
+++ b/breckFest/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/breckFest/breckFest.csproj
+++ b/breckFest/breckFest.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>breckFest</RootNamespace>
     <AssemblyName>Breckfest</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>


### PR DESCRIPTION
Made changed so that .tga, .png and .dds can all be decompressed though the command line. Also made them compatible with the -norename/-nr flag so when decompressing you can have the files keep the compressed naming format.

![image](https://github.com/user-attachments/assets/34338c91-9ffc-4ba2-b899-63b381208aaf)
